### PR TITLE
update debian dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ If you wish to build KeePassX from source, rather than rely on the pre-compiled 
 To install KeePassX from the Debian repository:
 
 ```bash
-sudo apt-get install keepassx
+sudo apt-get install keepassx xdotool
 ```
 
 ### Red Hat


### PR DESCRIPTION
With the debian 9 release the xdotool it's not installed by default and the autotype function doesn't work properly without the xdotool package, i think it would be good to suggest to install it if not to add it to the dependency packages list... don't know how to do it neither if it's right to do that.